### PR TITLE
style: format .kres.yaml

### DIFF
--- a/.kres.yaml
+++ b/.kres.yaml
@@ -15,5 +15,5 @@ spec:
 ---
 kind: common.Build
 spec:
-    ignoredPaths:
-      - go.work.sum
+  ignoredPaths:
+    - go.work.sum


### PR DESCRIPTION
I notice the wrong indent when working on Renovate.